### PR TITLE
#1: Add support for zipping nested folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Zipping a single file to a zip file with the same name:
 SimpleZipper::zipFile(QString("C:/Path/To/InputFile.ext"));
 ```
 
-Zipping all files in the root directory of a folder to a zip file with the same name:
+Zipping a folder to a zip file with the same name:
 
 ```c++
 SimpleZipper::zipFolder(QString("C:/Path/To/InputFolder"));
@@ -50,4 +50,3 @@ cd builds/bin/debug
 TestSimpleZipper.exe
 ```
 
-Or alternatively, call these directly from Visual Studio by setting `TestSimpleZipper` as the startup project.

--- a/src/SimpleZipper.cxx
+++ b/src/SimpleZipper.cxx
@@ -114,11 +114,13 @@ bool SimpleZipper::zipFile(const QString& filename, const QString& zipFilename)
     return true;
 }
 
-bool SimpleZipper::zipFolder(const QString& filename)
+bool SimpleZipper::zipFolder(const QString& folder)
 {
-    QFileInfo fileInfo(filename);
-    QString zipFilename = fileInfo.absoluteDir().path() + ".zip";
-    return zipFile(filename, zipFilename);
+    QDir dir(folder);
+    QString zipFilename = dir.dirName() + ".zip";
+    dir.cdUp();
+    zipFilename = dir.absolutePath() + "/" + zipFilename;
+    return zipFolder(folder, zipFilename);
 }
 
 bool SimpleZipper::zipFolder(const QString& folder, const QString& zipFilename)

--- a/src/SimpleZipper.h
+++ b/src/SimpleZipper.h
@@ -2,6 +2,7 @@
 #define SIMPLEZIPPER_HPP
 
 #include <QString>
+#include "miniz.h"
 
 /**
  * @class   SimpleZipper
@@ -56,8 +57,8 @@ public:
     /**
      * @brief   Zip a single file using miniz and Qt.
      *
-     * @details This function takes a file name as input and compresses it using the miniz library and the Qt file
-     *          abstraction classes. The default compression level is used.
+     * @details This function takes a file name and a zip file name as inputs and compresses it using the
+     *          miniz library and the Qt file abstraction classes. The default compression level is used.
      *
      * @param   fileName The name of the file to compress.
      * @param   zipFilename The name of the generated zip file.
@@ -67,11 +68,11 @@ public:
     static bool zipFile(const QString& filename, const QString& zipFilename);
 
     /**
-     * @brief   Zip a folder and all its contents using miniz and Qt.
+     * @brief   Zip a folder and all its contents recursively using miniz and Qt.
      *
-     * @details This function takes a folder name and a zip file name as input and compresses the root level
-     *          contents into a zip file using the miniz library and the Qt file abstraction classes.
-     *          The directory structures is NOT recursively traced. The default compression level is used.
+     * @details This function takes a folder name as input and compresses all the files in the folder and
+     *          its subfolders into a zip file using the miniz library and the Qt file abstraction classes
+     *          while preserving the directory structure. The default compression level is used.
      *          The compressed file is saved in the same directory as the input folder with a .zip
      *          extension.
      *
@@ -82,11 +83,12 @@ public:
     static bool zipFolder(const QString& folder);
 
     /**
-     * @brief   Zip a folder and all its contents using miniz and Qt.
+     * @brief   Zip a folder and all its contents recursively using miniz and Qt.
      *
-     * @details This function takes a folder name and a zip file name as input and compresses the root level
-     *          contents into a zip file using the miniz library and the Qt file abstraction classes.
-     *          The directory structures is NOT recursively traced. The default compression level is used.
+     * @details This function takes a folder name and a zip file name as inputs and compresses all the files
+     *          in the folder and its subfolders into a zip file using the miniz library and the Qt file
+     *          abstraction classes while preserving the directory structure. The default compression level
+     *          is used.
      *
      * @param   folder The name of the folder to compress.
      * @param   zipFilename The name of the zip file to create.
@@ -94,6 +96,21 @@ public:
      * @return  True if the folder was compressed successfully, false otherwise.
      */
     static bool zipFolder(const QString& folder, const QString& zipFilename);
+
+private:
+    /**
+     * @brief   Recursively add all files in a folder and its subfolders to a zip archive with the appropriate prefix.
+     *
+     * @details This function is used by zipFolder to traverse the directory tree and add all files and
+     *          subfolders to the zip archive with the appropriate directory structure.
+     *
+     * @param   zip A pointer to the miniz zip archive object to add files to.
+     * @param   folder The name of the folder to add files from.
+     * @param   prefix The prefix to add to the file names in the zip archive to preserve the directory structure.
+     *
+     * @return  True if all files were added successfully, false otherwise.
+     */
+    static bool addFolderToZip(mz_zip_archive* zip, const QString& folder, const QString& prefix);
 };
 
 #endif // SIMPLEZIPPER_HPP

--- a/test/TestSimpleZipper.h
+++ b/test/TestSimpleZipper.h
@@ -12,8 +12,8 @@
  * @brief   Unit tests for SimpleZipper class.
  *
  * @details The TestSimpleZipper class implements unit tests for the static methods in the SimpleZipper class.
- *          It creates three text files, and zips and unzips these by file and folder, and checks the file
- *          contents survive the zip-unzip.
+ *          It creates three text files and a subdirectory with two text files, and zips and unzips these by file and folder,
+ *          and checks the file contents survive the zip-unzip.
  */
 class TestSimpleZipper : public QObject {
     Q_OBJECT
@@ -23,10 +23,13 @@ private:
     QFile mFile1;
     QFile mFile2;
     QFile mFile3;
+    QDir mSubDir;
+    QFile mSubFile1;
+    QFile mSubFile2;
 
 private slots:
     /**
-     * @brief Creates a temporary directory with three text files.
+     * @brief Creates a temporary directory with three text files and a subdirectory with two text files.
      */
     void initTestCase() {
         // Create a temporary directory
@@ -48,6 +51,20 @@ private slots:
         QVERIFY(mFile3.open(QIODevice::WriteOnly));
         mFile3.write("Lorem Ipsum.");
         mFile3.close();
+
+        // Create a subdirectory with two text files
+        mSubDir = QDir(mTempDir.filePath("subdir"));
+        QVERIFY(mSubDir.mkpath("."));
+
+        mSubFile1.setFileName(mSubDir.filePath("mSubFile1.txt"));
+        QVERIFY(mSubFile1.open(QIODevice::WriteOnly));
+        mSubFile1.write("Sub File 1");
+        mSubFile1.close();
+
+        mSubFile2.setFileName(mSubDir.filePath("mSubFile2.txt"));
+        QVERIFY(mSubFile2.open(QIODevice::WriteOnly));
+        mSubFile2.write("Sub File 2");
+        mSubFile2.close();
     }
 
     /**
@@ -56,7 +73,9 @@ private slots:
     void testZipDirectory()
     {
         // Name for zip file
-        QString zipPath = mTempDir.filePath("testZipper.zip");
+        QDir parentDir = mTempDir;
+        parentDir.cdUp();
+        QString zipPath = parentDir.filePath("testZipper.zip");
 
         // Zip the temporary directory
         QVERIFY(SimpleZipper::zipFolder(mTempDir.absolutePath(), zipPath));
@@ -74,23 +93,33 @@ private slots:
         QFile unzippedFile1(tempUnzipDir + "/mFile1.txt");
         QFile unzippedFile2(tempUnzipDir + "/mFile2.txt");
         QFile unzippedFile3(tempUnzipDir + "/mFile3.txt");
+        QFile unzippedSubFile1(tempUnzipDir + "/subdir/mSubFile1.txt");
+        QFile unzippedSubFile2(tempUnzipDir + "/subdir/mSubFile2.txt");
 
         QVERIFY(unzippedFile1.open(QIODevice::ReadOnly));
         QVERIFY(unzippedFile2.open(QIODevice::ReadOnly));
         QVERIFY(unzippedFile3.open(QIODevice::ReadOnly));
+        QVERIFY(unzippedSubFile1.open(QIODevice::ReadOnly));
+        QVERIFY(unzippedSubFile2.open(QIODevice::ReadOnly));
 
         QVERIFY(mFile1.open(QIODevice::ReadOnly));
         QVERIFY(mFile2.open(QIODevice::ReadOnly));
         QVERIFY(mFile3.open(QIODevice::ReadOnly));
+        QVERIFY(mSubFile1.open(QIODevice::ReadOnly));
+        QVERIFY(mSubFile2.open(QIODevice::ReadOnly));
 
         QCOMPARE(unzippedFile1.readAll(), mFile1.readAll());
         QCOMPARE(unzippedFile2.readAll(), mFile2.readAll());
         QCOMPARE(unzippedFile3.readAll(), mFile3.readAll());
+        QCOMPARE(unzippedSubFile1.readAll(), mSubFile1.readAll());
+        QCOMPARE(unzippedSubFile2.readAll(), mSubFile2.readAll());
 
         // Close original files
         mFile1.close();
         mFile2.close();
         mFile3.close();
+        mSubFile1.close();
+        mSubFile2.close();
     }
 
     /**


### PR DESCRIPTION
## Summary

- Adds support for zipping nested folders.
- Fixes bug in `SimpleZipper::zipFolder(const QString& folder)` (called `zipFile` instead of `zipFolder`, used name of parent directory)

## Testing

- Extended scope of `TestSimpleZipper` to use data with a nested folder.

## Related Issues

* Closes #1

## Peer Review

Review summary (complete before merge):

* [x] Implementation is sensible
* [x] All code is documented
* [x] Code meets coding standard
* [x] New unit test/s implemented and cover scope (if applicable)
* [x] All unit test/s pass
* [x] Issue description is complete
