### PR TITLE
CI on GitHub actions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,19 +17,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    # installing Qt takes ~ 5 mins so cache to speed up
-    - name: Cache Qt5
-      id: cache-qt
-      uses: actions/cache@v3
-      with:
-        path: ${{github.workspace}}/Qt
-        key: cache_qt
-
     - name: Install Qt5
       uses: jurplel/install-qt-action@v3
       with:
         version: '5.15.2'
-        cache: true # don't redownload if the files are available (still sets up the enviromnent)
+        cache: true 
+        # Don't redownload if the files are available (still sets up the enviromnent).
+        # This reduces ~5 mins (first time) to ~3 mins.
         
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,5 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest -C ${{env.BUILD_TYPE}}
+      run: ctest -C ${{env.BUILD_TYPE}} --extra-verbose
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,6 @@ jobs:
       uses: jurplel/install-qt-action@v3
       with:
         version: '5.15.2'
-        cache: true 
-        # Don't redownload if the files are available (still sets up the enviromnent).
-        # This reduces ~5 mins (first time) to ~3 mins.
         
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+env:
+  BUILD_TYPE: Debug
+
+jobs:
+  build_and_test:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    # installing Qt takes ~ 5 mins so cache to speed up
+    - name: Cache Qt5
+      id: cache-qt
+      uses: actions/cache@v3
+      with:
+        path: ${{github.workspace}}/Qt
+        key: cache_qt
+
+    - name: Install Qt5
+      uses: jurplel/install-qt-action@v3
+      with:
+        version: '5.15.2'
+        cache: true # don't redownload if the files are available (still sets up the enviromnent)
+        
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{env.BUILD_TYPE}}
+


### PR DESCRIPTION
* Adds a ci.yaml which is very close to the cookiecut CMake C++ action that GitHub provides.
    * Runs a build and `ctest` on all pushes to `main`, all PRs to `main` and you'll be able to manually run via the "Actions" tab.
* I make use of [jurplel/install-qt-action](https://github.com/jurplel/install-qt-action) (👍 ) to install Qt 5.12.2 (LTS) for QTest.
* [Tests pass](https://github.com/samcunliffe/simple-zipper/actions/runs/5608121366/jobs/10260082291#step:6:16) 🎉  on `main`.

Installing Qt5 takes ~5mins. I investigated caching the Qt download but the option seems not to work (a not working cache still passes, but takes longer, so we don't make a time saving). Turned that off for now, will report upstream.